### PR TITLE
force recognition to start when it ends

### DIFF
--- a/src/Transcripts/Transcripts.js
+++ b/src/Transcripts/Transcripts.js
@@ -97,12 +97,8 @@ class Transcripts extends React.Component {
       };
   
       this.recognition.onend = () => {
-        if (this.state.ignoreOnend) {
-          return;
-        }
-        if (!this.state.finalTranscript) {
-          return;
-        }
+        if (!this.state.recording) return;
+        this.recognition.start();
       };
   
       this.recognition.onresult = async (event) => {


### PR DESCRIPTION
Simple work to force websocket recognition to restart when it ends, unless our client end flag is set to true